### PR TITLE
Add FIQL filtering to alarms, events, and nodes endpoints.

### DIFF
--- a/pyonms/__init__.py
+++ b/pyonms/__init__.py
@@ -1,6 +1,6 @@
 # __init__.py
 
-
+# flake8: noqa W503
 # cSpell: ignore UDLAPI
 
 """

--- a/pyonms/dao/alarms.py
+++ b/pyonms/dao/alarms.py
@@ -20,14 +20,18 @@ class AlarmAPI(Endpoint):
             return None
 
     def get_alarms(
-        self, limit: int = 100, batch_size: int = 100
+        self, fiql: str = None, limit: int = 100, batch_size: int = 100
     ) -> List[Optional[pyonms.models.alarm.Alarm]]:
         alarms = []
+        params = {}
+        if fiql:
+            params["_s"] = fiql
         records = self._get_batch(
             url=self.url,
             endpoint="alarm",
             limit=limit,
             batch_size=batch_size,
+            params=params,
         )
         if records == [None]:
             return [None]

--- a/pyonms/dao/events.py
+++ b/pyonms/dao/events.py
@@ -20,14 +20,18 @@ class EventAPI(Endpoint):
             return None
 
     def get_events(
-        self, limit=100, batch_size=100
+        self, fiql: str = None, limit: int = 100, batch_size: int = 100
     ) -> List[Union[pyonms.models.event.Event, None]]:
         events = []
+        params = {}
+        if fiql:
+            params["_s"] = fiql
         records = self._get_batch(
             url=self.url,
             endpoint="event",
             limit=limit,
             batch_size=batch_size,
+            params=params,
         )
         if records == [None]:
             return [None]

--- a/pyonms/dao/nodes.py
+++ b/pyonms/dao/nodes.py
@@ -37,13 +37,16 @@ class NodeAPI(Endpoint):
 
     def get_nodes(
         self,
-        limit=100,
-        batch_size=100,
+        fiql: str = None,
+        limit: int = 100,
+        batch_size: int = 100,
         components: List[NodeComponents] = [],
         threads: int = 10,
     ) -> List[Optional[pyonms.models.node.Node]]:
         devices = []
         params = {}
+        if fiql:
+            params["_s"] = fiql
         records = self._get_batch(
             url=self.url,
             endpoint="node",


### PR DESCRIPTION
* Added optional `fiql` parameter to the `get_nodes`, `get_alarms`, and `get_events` endpoints that can be used to filter the results returned.